### PR TITLE
Update Documentation action

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,4 +19,5 @@ jobs:
     uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@main"
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
-    secrets: "inherit"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,15 +12,12 @@
 This package resides in the `ITensor/ITensorRegistry` local registry.
 In order to install, simply add that registry through your package manager.
 This step is only required once.
-
 ```julia
 julia> using Pkg: Pkg
 
 julia> Pkg.Registry.add(url="https://github.com/ITensor/ITensorRegistry")
 ```
-
 Then, the package can be added as usual through the package manager:
-
 
 ```julia
 julia> Pkg.add("ITensorPkgSkeleton")

--- a/templates/github/.github/workflows/Documentation.yml
+++ b/templates/github/.github/workflows/Documentation.yml
@@ -19,4 +19,5 @@ jobs:
     uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@main"
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
-    secrets: "inherit"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This fixes an issue where the codecov token now needs to be explicitly passed on in the documentation action.