### PR TITLE
Update CI badge to Tests badge

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ITensor.github.io/ITensorPkgSkeleton.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ITensor.github.io/ITensorPkgSkeleton.jl/dev/)
-[![Build Status](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/Tests.yml/badge.svg?branch=main)](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/Tests.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/ITensor/ITensorPkgSkeleton.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/ITensor/ITensorPkgSkeleton.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -2,7 +2,7 @@
 # 
 # [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ITensor.github.io/ITensorPkgSkeleton.jl/stable/)
 # [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ITensor.github.io/ITensorPkgSkeleton.jl/dev/)
-# [![Build Status](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/CI.yml?query=branch%3Amain)
+# [![Build Status](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/Tests.yml/badge.svg?branch=main)](https://github.com/ITensor/ITensorPkgSkeleton.jl/actions/workflows/Tests.yml?query=branch%3Amain)
 # [![Coverage](https://codecov.io/gh/ITensor/ITensorPkgSkeleton.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/ITensor/ITensorPkgSkeleton.jl)
 # [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 # [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)

--- a/templates/docs/README.md
+++ b/templates/docs/README.md
@@ -2,7 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ITensor.github.io/{PKGNAME}.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ITensor.github.io/{PKGNAME}.jl/dev/)
-[![Build Status](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/Tests.yml/badge.svg?branch=main)](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/Tests.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/ITensor/{PKGNAME}.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/ITensor/{PKGNAME}.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)

--- a/templates/examples/examples/README.jl
+++ b/templates/examples/examples/README.jl
@@ -2,7 +2,7 @@
 # 
 # [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ITensor.github.io/{PKGNAME}.jl/stable/)
 # [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ITensor.github.io/{PKGNAME}.jl/dev/)
-# [![Build Status](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/CI.yml?query=branch%3Amain)
+# [![Build Status](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/Tests.yml/badge.svg?branch=main)](https://github.com/ITensor/{PKGNAME}.jl/actions/workflows/Tests.yml?query=branch%3Amain)
 # [![Coverage](https://codecov.io/gh/ITensor/{PKGNAME}.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/ITensor/{PKGNAME}.jl)
 # [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 # [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)


### PR DESCRIPTION
This fixes an issue where the badges for the CI were still pointing to the wrong link.