### PR TITLE
Test Project.toml structure and suppressor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,22 +13,11 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
-Aqua = "0.8.9"
 DocStringExtensions = "0.9.3"
 Git = "1.3.1"
 Git_jll = "2.46.2"
 LibGit2 = "1.10"
 PkgSkeleton = "1.3.1"
 Preferences = "1.4.3"
-SafeTestsets = "0.1"
 Suppressor = "0.2.8"
-Test = "1.10"
 julia = "1.10"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Aqua", "Test", "SafeTestsets"]

--- a/templates/project/Project.toml
+++ b/templates/project/Project.toml
@@ -4,17 +4,4 @@ authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.1.0"
 
 [compat]
-Aqua = "0.8.9"
-SafeTestsets = "0.1"
-Suppressor = "0.2"
-Test = "1.10"
 julia = "1.10"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
-
-[targets]
-test = ["Aqua", "Test", "Suppressor", "SafeTestsets"]

--- a/templates/test/test/Project.toml
+++ b/templates/test/test/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.8.9"
+SafeTestsets = "0.1"
+Suppressor = "0.2"
+Test = "1.10"

--- a/templates/test/test/runtests.jl
+++ b/templates/test/test/runtests.jl
@@ -45,7 +45,12 @@ end
     filename = basename(file)
     @eval begin
       @safetestset $filename begin
-        $(Expr(:macrocall, GlobalRef(Suppressor, Symbol("@suppress")), LineNumberNode(@__LINE__, @__FILE__), :(include($file))))
+        $(Expr(
+          :macrocall,
+          GlobalRef(Suppressor, Symbol("@suppress")),
+          LineNumberNode(@__LINE__, @__FILE__),
+          :(include($file)),
+        ))
       end
     end
   end

--- a/templates/test/test/runtests.jl
+++ b/templates/test/test/runtests.jl
@@ -1,5 +1,5 @@
 using SafeTestsets: @safetestset
-using Suppressor: @suppress
+using Suppressor: Suppressor
 
 # check for filtered groups
 # either via `--group=ALL` or through ENV["GROUP"]
@@ -42,8 +42,11 @@ end
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
   for file in filter(endswith(".jl"), readdir(examplepath; join=true))
-    @suppress @eval @safetestset $file begin
-      include($file)
+    filename = basename(file)
+    @eval begin
+      @safetestset $filename begin
+        $(Expr(:macrocall, GlobalRef(Suppressor, Symbol("@suppress")), LineNumberNode(@__LINE__, @__FILE__), :(include($file))))
+      end
     end
   end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.8.9"
+SafeTestsets = "0.1"
+Suppressor = "0.2"
+Test = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,12 @@ end
     filename = basename(file)
     @eval begin
       @safetestset $filename begin
-        $(Expr(:macrocall, GlobalRef(Suppressor, Symbol("@suppress")), LineNumberNode(@__LINE__, @__FILE__), :(include($file))))
+        $(Expr(
+          :macrocall,
+          GlobalRef(Suppressor, Symbol("@suppress")),
+          LineNumberNode(@__LINE__, @__FILE__),
+          :(include($file)),
+        ))
       end
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using SafeTestsets: @safetestset
-using Suppressor: @suppress
+using Suppressor: Suppressor
 
 # check for filtered groups
 # either via `--group=ALL` or through ENV["GROUP"]
@@ -42,8 +42,11 @@ end
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
   for file in filter(endswith(".jl"), readdir(examplepath; join=true))
-    @suppress @eval @safetestset $file begin
-      include($file)
+    filename = basename(file)
+    @eval begin
+      @safetestset $filename begin
+        $(Expr(:macrocall, GlobalRef(Suppressor, Symbol("@suppress")), LineNumberNode(@__LINE__, @__FILE__), :(include($file))))
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed with @mtfishman, we switch to the other convention of specifying test dependencies, using a `test/Project.toml` file instead of the `[extras]` section in the main project file.

Simultaneously, I fixed an issue where the examples testsets were being suppressed.

As a remark, at this point it might become cleaner to define our own `@safetestset` which supports interpolation, and `@safeexampleset` which suppresses the output. [TestExtras.jl](https://github.com/Jutho/TestExtras.jl) might be a convenient place to put this.

Closes #35 
Closes #36 