### PR TITLE
Add functionality for loading setup code

### DIFF
--- a/templates/test/test/runtests.jl
+++ b/templates/test/test/runtests.jl
@@ -13,11 +13,12 @@ const GROUP = uppercase(
   end,
 )
 
-function istestfile(filename)
-  return isfile(filename) &&
-         endswith(filename, ".jl") &&
-         startswith(basename(filename), "test")
-end
+"match files of the form `test_*.jl`, but exclude `*setup*.jl`"
+istestfile(fn) =
+  endswith(fn, ".jl") && startswith(basename(fn), "test_") && !contains(fn, "setup")
+"match files of the form `*.jl`, but exclude `*_notest.jl` and `*setup*.jl`"
+isexamplefile(fn) =
+  endswith(fn, ".jl") && !endswith(fn, "_notest.jl") && !contains(fn, "setup")
 
 @time begin
   # tests in groups based on folder structure
@@ -33,7 +34,7 @@ end
 
   # single files in top folder
   for file in filter(istestfile, readdir(@__DIR__))
-    (file == basename(@__FILE__)) && continue
+    (file == basename(@__FILE__)) && continue # exclude this file to avoid infinite recursion
     @eval @safetestset $file begin
       include($file)
     end
@@ -41,16 +42,19 @@ end
 
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
-  for file in filter(endswith(".jl"), readdir(examplepath; join=true))
-    filename = basename(file)
-    @eval begin
-      @safetestset $filename begin
-        $(Expr(
-          :macrocall,
-          GlobalRef(Suppressor, Symbol("@suppress")),
-          LineNumberNode(@__LINE__, @__FILE__),
-          :(include($file)),
-        ))
+  for (root, _, files) in walkdir(examplepath)
+    contains(root, "setup") && continue
+    for file in filter(isexamplefile, files)
+      filename = joinpath(root, file)
+      @eval begin
+        @safetestset $file begin
+          $(Expr(
+            :macrocall,
+            GlobalRef(Suppressor, Symbol("@suppress")),
+            LineNumberNode(@__LINE__, @__FILE__),
+            :(include($filename)),
+          ))
+        end
       end
     end
   end

--- a/templates/test/test/runtests.jl
+++ b/templates/test/test/runtests.jl
@@ -43,7 +43,7 @@ isexamplefile(fn) =
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
   for (root, _, files) in walkdir(examplepath)
-    contains(root, "setup") && continue
+    contains(chopprefix(root, @__DIR__), "setup") && continue
     for file in filter(isexamplefile, files)
       filename = joinpath(root, file)
       @eval begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,11 +13,12 @@ const GROUP = uppercase(
   end,
 )
 
-function istestfile(filename)
-  return isfile(filename) &&
-         endswith(filename, ".jl") &&
-         startswith(basename(filename), "test")
-end
+"match files of the form `test_*.jl`, but exclude `*setup*.jl`"
+istestfile(fn) =
+  endswith(fn, ".jl") && startswith(basename(fn), "test_") && !contains(fn, "setup")
+"match files of the form `*.jl`, but exclude `*_notest.jl` and `*setup*.jl`"
+isexamplefile(fn) =
+  endswith(fn, ".jl") && !endswith(fn, "_notest.jl") && !contains(fn, "setup")
 
 @time begin
   # tests in groups based on folder structure
@@ -33,7 +34,7 @@ end
 
   # single files in top folder
   for file in filter(istestfile, readdir(@__DIR__))
-    (file == basename(@__FILE__)) && continue
+    (file == basename(@__FILE__)) && continue # exclude this file to avoid infinite recursion
     @eval @safetestset $file begin
       include($file)
     end
@@ -41,16 +42,19 @@ end
 
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
-  for file in filter(endswith(".jl"), readdir(examplepath; join=true))
-    filename = basename(file)
-    @eval begin
-      @safetestset $filename begin
-        $(Expr(
-          :macrocall,
-          GlobalRef(Suppressor, Symbol("@suppress")),
-          LineNumberNode(@__LINE__, @__FILE__),
-          :(include($file)),
-        ))
+  for (root, _, files) in walkdir(examplepath)
+    contains(root, "setup") && continue
+    for file in filter(isexamplefile, files)
+      filename = joinpath(root, file)
+      @eval begin
+        @safetestset $file begin
+          $(Expr(
+            :macrocall,
+            GlobalRef(Suppressor, Symbol("@suppress")),
+            LineNumberNode(@__LINE__, @__FILE__),
+            :(include($filename)),
+          ))
+        end
       end
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ isexamplefile(fn) =
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
   for (root, _, files) in walkdir(examplepath)
-    contains(root, "setup") && continue
+    contains(chopprefix(root, @__DIR__), "setup") && continue
     for file in filter(isexamplefile, files)
       filename = joinpath(root, file)
       @eval begin


### PR DESCRIPTION
This is a proposition to allow loading setup code through setup modules in either `test/setup/` or `examples/setup/`. It basically allows any module defined in those folders to be loaded from the tests by `using SetupModule`.

As a small FYI/question: currently I'm not explicitly blacklisting that folder from the testfiles, and testfiles are still selected on `test_*.jl`. I'm not sure if this is important to catch.