### PR TITLE
Format testset names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/templates/test/test/runtests.jl
+++ b/templates/test/test/runtests.jl
@@ -24,9 +24,11 @@ isexamplefile(fn) =
   # tests in groups based on folder structure
   for testgroup in filter(isdir, readdir(@__DIR__))
     if GROUP == "ALL" || GROUP == uppercase(testgroup)
-      for file in filter(istestfile, readdir(joinpath(@__DIR__, testgroup); join=true))
+      groupdir = joinpath(@__DIR__, testgroup)
+      for file in filter(istestfile, readdir(groupdir))
+        filename = joinpath(groupdir, file)
         @eval @safetestset $file begin
-          include($file)
+          include($filename)
         end
       end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,11 @@ isexamplefile(fn) =
   # tests in groups based on folder structure
   for testgroup in filter(isdir, readdir(@__DIR__))
     if GROUP == "ALL" || GROUP == uppercase(testgroup)
-      for file in filter(istestfile, readdir(joinpath(@__DIR__, testgroup); join=true))
+      groupdir = joinpath(@__DIR__, testgroup)
+      for file in filter(istestfile, readdir(groupdir))
+        filename = joinpath(groupdir, file)
         @eval @safetestset $file begin
-          include($file)
+          include($filename)
         end
       end
     end


### PR DESCRIPTION
This assigns testsets to just the group + filename instead of the full path:
(example from SparseArraysBase)
Before:
```julia
Test Summary:                                                         | Pass  Total  Time
/Users/ldevos/Projects/SparseArraysBase.jl/test/basics/test_basics.jl |  240    240  2.7s
Test Summary:                                                           | Pass  Total  Time
/Users/ldevos/Projects/SparseArraysBase.jl/test/basics/test_diagonal.jl |   24     24  0.3s
Test Summary:                                                          | Pass  Total  Time
/Users/ldevos/Projects/SparseArraysBase.jl/test/basics/test_exports.jl |    1      1  0.1s
```

After
```julia
     Testing Running tests...
Test Summary:          | Pass  Total  Time
/basics/test_basics.jl |  240    240  2.7s
Test Summary:            | Pass  Total  Time
/basics/test_diagonal.jl |   24     24  0.3s
Test Summary:           | Pass  Total  Time
/basics/test_exports.jl |    1      1  0.1s
```