### PR TITLE
Integration tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/templates/github/.github/workflows/IntegrationRequest.yml
+++ b/templates/github/.github/workflows/IntegrationRequest.yml
@@ -1,0 +1,41 @@
+name: "Integration Request"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  get-pr-comment:
+    if: |
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    outputs:
+      repo: ${{ steps.step1.outputs.group2 }}
+      status: ${{ steps.step1.outputs.match }}
+    steps:
+      - id: step1
+        uses: KyoriPowered/action-regex-match@v3
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '^(@integrationtests )(.*)$'
+      - id: debug
+        run: echo "${{ steps.step1.outputs.match }}"
+
+  runtests:
+    needs: get-pr-comment
+    if: ${{ needs.get-pr-comment.outputs.status != '' }}
+    uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
+    with:
+      localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+      repo: "${{ needs.get-pr-comment.outputs.repo }}"
+
+  report:
+    needs: [get-pr-comment, runtests]
+    if: ${{ success() && needs.get-pr-comment.outputs.status != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '+1'


### PR DESCRIPTION
This PR adds the workflow for requesting integration tests on PRs.
The syntax for achieving this is `@` `integrationtests` `Repo/Packagename.jl` (concatenated), which will then go in and run these tests against the code in the PR.
The status of these tests can be inspected manually in the "Actions" tab, but upon success the bot will react with `+1` on that comment. 