### PR TITLE
Only run FormatCheck on PRs

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,10 +1,6 @@
 name: "Format Check"
 
 on:
-  push:
-    branches:
-      - 'main'
-    tags: '*'
   pull_request:
 
 permissions:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.19"
+version = "0.3.20"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/templates/github/.github/workflows/FormatCheck.yml
+++ b/templates/github/.github/workflows/FormatCheck.yml
@@ -1,17 +1,13 @@
 name: "Format Check"
 
+on:
+  pull_request:
+
 permissions:
   contents: read
   checks: write
   issues: write
   pull-requests: write
-
-on:
-  push:
-    branches:
-      - 'main'
-    tags: '*'
-  pull_request:
 
 jobs:
   format-check:


### PR DESCRIPTION
The [FormatCheck.yml workflow in ITensorActions](https://github.com/ITensor/ITensorActions/blob/60cc8f9130bd315b0a7a95ba707f726328bdf6a6/.github/workflows/FormatCheck.yml), based on the one in [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl/blob/v5.9.0/.github/workflows/Format.yml), only works on PRs, so this change only runs it on PRs.