### PR TITLE
Switch IntegrationTest to pull_request_target, add fail-fast false

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -6,7 +6,7 @@ on:
     tags: "*"
     paths:
       - "Project.toml"
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
       - "synchronize"
@@ -19,6 +19,7 @@ jobs:
   integration-test:
     name: "IntegrationTest"
     strategy:
+      fail-fast: false
       matrix:
         pkg:
           - "__none__"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.47"
+version = "0.3.48"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -6,7 +6,7 @@ on:
     tags: "*"
     paths:
       - "Project.toml"
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
       - "synchronize"
@@ -19,10 +19,12 @@ jobs:
   integration-test:
     name: "IntegrationTest"
     strategy:
+      fail-fast: false
       matrix:
         pkg:
 {DOWNSTREAMPKGS}
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       pkg: "${{ matrix.pkg }}"


### PR DESCRIPTION
## Summary

- `pull_request` → `pull_request_target` (secrets available for fork PRs)
- Add `fail-fast: false` (one failure doesn't cancel others)
- Add `secrets: "inherit"` to template (was missing)
- Updated both `.github/workflows/` and `template/` versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)