### PR TITLE
Drop paths filter from IntegrationTest trigger

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - "main"
     tags: "*"
-    paths:
-      - "Project.toml"
   pull_request_target:
     types:
       - "opened"
@@ -13,8 +11,6 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
-    paths:
-      - "Project.toml"
 jobs:
   integration-test:
     name: "IntegrationTest"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.48"
+version = "0.3.49"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -4,8 +4,6 @@ on:
     branches:
       - "main"
     tags: "*"
-    paths:
-      - "Project.toml"
   pull_request_target:
     types:
       - "opened"
@@ -13,8 +11,6 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
-    paths:
-      - "Project.toml"
 jobs:
   integration-test:
     name: "IntegrationTest"


### PR DESCRIPTION
## Summary

- Remove `paths: ["Project.toml"]` from both the `push:` and `pull_request_target:` triggers of `IntegrationTest.yml`, in the template and the installed workflow.
- Bump patch version to 0.3.49.

## Motivation

Previously, PRs that didn't touch `Project.toml` didn't trigger the workflow at all, leaving the required `IntegrationTest` branch-protection context hanging on "Waiting for status to be reported" (e.g. ITensor/ITensorDocs.jl#49, ITensor/ITensorDocsNext.jl#44).

Now `IntegrationTest` runs on every non-draft PR; drafts continue to skip the downstream matrix via the reusable workflow's `run-on-draft: false` default. Draft/ready-for-review is the right knob to control running the downstream tests. Running integration tests on workflow-only PRs is the safer default since workflow edits can affect how the tests run.

## Follow-up

A companion MassApplyPatch (`integrationtest_drop_paths_filter` in ITensorOrgPatches) will propagate this change to the 27 ecosystem repos.

## Test plan

- [ ] Verify this PR itself runs `IntegrationTest` successfully on the skeleton repo.
- [ ] After mass-apply, verify unblocked PRs (ITensor/ITensorDocs.jl#49, etc.) complete the required `IntegrationTest` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)