### PR TITLE
Add CheckCompatBounds.yml template and repo workflow

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,0 +1,9 @@
+name: "Check Compat Bounds"
+on:
+  pull_request: ~
+jobs:
+  check-compat-bounds:
+    name: "Check Compat Bounds"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@main"
+    with:
+      localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.49"
+version = "0.3.50"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/CheckCompatBounds.yml.template
+++ b/template/.github/workflows/CheckCompatBounds.yml.template
@@ -1,0 +1,9 @@
+name: "Check Compat Bounds"
+on:
+  pull_request: ~
+jobs:
+  check-compat-bounds:
+    name: "Check Compat Bounds"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@main"
+    with:
+      localregistry: "https://github.com/ITensor/ITensorRegistry.git"


### PR DESCRIPTION
## Summary

Follow-up to [ITensorActions#69](https://github.com/ITensor/ITensorActions/pull/69), which introduced the `CheckCompatBounds.yml` reusable workflow. This PR adds the caller workflow to ITensorPkgSkeleton.jl so:

- New packages generated from the skeleton get the check out of the box.
- `ITensorOrgPatches` / `MassApplyPatch` can pick the file up via `add_template_file!(\".github/workflows/CheckCompatBounds.yml\")` and roll it out across existing ecosystem packages.

Added in both locations (per the skeleton's convention):
- `.github/workflows/CheckCompatBounds.yml` — the skeleton's own CI.
- `template/.github/workflows/CheckCompatBounds.yml.template` — the template.

Patch version bumped to 0.3.50 since this is a substantive template change.