### PR TITLE
Add `JuliaRegistries/TagBot` marker to TagBot.yml so General-side trigger fires

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,8 @@ on:
     types:
       - "created"
   workflow_dispatch: ~
+env:
+  REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.50"
+version = "0.3.51"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/TagBot.yml.template
+++ b/template/.github/workflows/TagBot.yml.template
@@ -4,6 +4,8 @@ on:
     types:
       - "created"
   workflow_dispatch: ~
+env:
+  REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"


### PR DESCRIPTION
## Summary

`JuliaRegistries/General`'s post-merge `TagBot Triggers` workflow runs `RegistryCI.TagBot.maybe_notify()`, which only treats TagBot as enabled on a package repo if the literal substring `JuliaRegistries/TagBot` appears in some file under `.github/workflows/` (see [RegistryCI.jl `tagbot_file`](https://github.com/JuliaRegistries/RegistryCI.jl/blob/master/AutoMerge/src/TagBot/TagBot.jl#L62-L77)).

After this repo's `TagBot.yml` was migrated to delegate to the shared reusable workflow at `ITensor/ITensorActions/.github/workflows/TagBot.yml@main`, the caller no longer contains that string — the actual `JuliaRegistries/TagBot` invocation lives in the reusable workflow, which the check does not follow. As a result:

- `JuliaTagBot`'s trigger comment is never posted on new General-only registrations.
- The package-side workflow never fires (it gates on `actor == 'JuliaTagBot'`).
- Tags silently stop being created.

This is the source of accumulated tag backlogs on General-only packages such as `ITensorNetworks.jl`, `ITensorMPS.jl`, `NamedGraphs.jl`, `TypeParameterAccessors.jl` (for its 0.4.x line), and several others. ITensorRegistry-registered packages are unaffected because ITensorRegistry has its own dispatch-based trigger that bypasses this check entirely.

This PR adds a top-level `env:` entry whose value contains the literal substring so the check passes. The variable is unreferenced — it has no runtime effect and does not propagate into the reusable workflow.

A YAML comment would be simpler, but `itpkgfmt`'s YAML formatter strips comments, so the marker has to live in a structural element.

## Test plan

- [x] `itpkgfmt` leaves the `env:` block unchanged.
- [x] `python3 -c 'print("JuliaRegistries/TagBot" in open(".github/workflows/TagBot.yml").read())'` returns `True`.
- [x] `pre-commit run` passes (yaml, end-of-files, ITensor Pkg Formatter).
- [ ] After merge: roll the same change to every reusable-workflow-adopting ITensor org repo via `MassApplyPatch`, then dispatch a one-shot backfill of TagBot on each repo with a tag gap. (Followup work.)
- [ ] After merge: confirm next live General registration on a swept repo posts a `JuliaTagBot` trigger comment and tags automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)