### PR TITLE
README: document the workflow templates and the TagBot `env:` marker

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.51"
+version = "0.3.52"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ ITensorPkgSkeleton.generate("MyPackage")
 
 Examples go here.
 
+## Workflow templates
+
+The `template/.github/workflows/` directory is the source of truth for the GitHub Actions
+workflows shared across the ITensor ecosystem (`Tests.yml`, `FormatCheck.yml`, `TagBot.yml`,
+`CompatHelper.yml`, etc.). Most of them simply call into reusable workflows in
+[ITensorActions](https://github.com/ITensor/ITensorActions); see that repository's README
+for details on each.
+
+`TagBot.yml` carries a marker `env: REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"`
+that looks unused but is required: the General registry's trigger workflow only treats
+TagBot as enabled when the literal string `JuliaRegistries/TagBot` appears in a file
+under `.github/workflows/`, and the reusable-workflow caller would otherwise not
+contain it. The same string would work as a YAML comment, but
+[ITensorFormatter](https://github.com/ITensor/ITensorFormatter.jl) (`itpkgfmt`) strips
+YAML comments via [YAML.jl](https://github.com/JuliaData/YAML.jl)'s writer (tracked
+upstream at [YAML.jl#245](https://github.com/JuliaData/YAML.jl/issues/245)), so the
+marker has to live in a structural element. See
+[ITensorActions's TagBot docs](https://github.com/ITensor/ITensorActions#why-the-env-marker)
+for the full explanation. Do not remove this `env:` block.
+
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -46,3 +46,23 @@ julia> Pkg.add("ITensorPkgSkeleton")
 using ITensorPkgSkeleton: ITensorPkgSkeleton
 ITensorPkgSkeleton.generate("MyPackage")
 # Examples go here.
+
+# ## Workflow templates
+#
+# The `template/.github/workflows/` directory is the source of truth for the GitHub Actions
+# workflows shared across the ITensor ecosystem (`Tests.yml`, `FormatCheck.yml`, `TagBot.yml`,
+# `CompatHelper.yml`, etc.). Most of them simply call into reusable workflows in
+# [ITensorActions](https://github.com/ITensor/ITensorActions); see that repository's README
+# for details on each.
+#
+# `TagBot.yml` carries a marker `env: REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"`
+# that looks unused but is required: the General registry's trigger workflow only treats
+# TagBot as enabled when the literal string `JuliaRegistries/TagBot` appears in a file
+# under `.github/workflows/`, and the reusable-workflow caller would otherwise not
+# contain it. The same string would work as a YAML comment, but
+# [ITensorFormatter](https://github.com/ITensor/ITensorFormatter.jl) (`itpkgfmt`) strips
+# YAML comments via [YAML.jl](https://github.com/JuliaData/YAML.jl)'s writer (tracked
+# upstream at [YAML.jl#245](https://github.com/JuliaData/YAML.jl/issues/245)), so the
+# marker has to live in a structural element. See
+# [ITensorActions's TagBot docs](https://github.com/ITensor/ITensorActions#why-the-env-marker)
+# for the full explanation. Do not remove this `env:` block.


### PR DESCRIPTION
## Summary

Add a "Workflow templates" section to the README explaining what `template/.github/workflows/` is for and calling out the `TagBot.yml` marker `env: REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"` so future readers don't remove it as dead code.

The marker exists because the General registry's [TagBotTriggers workflow](https://github.com/JuliaRegistries/General/blob/master/.github/workflows/TagBotTriggers.yml) runs `RegistryCI.TagBot.maybe_notify`, which only treats TagBot as enabled on a package repo if the literal substring `JuliaRegistries/TagBot` appears in some file under `.github/workflows/`. After delegating to the reusable workflow at [ITensorActions](https://github.com/ITensor/ITensorActions), the caller no longer contains that string, so the substring check fails. The unused `env:` variable carries the literal substring so the check passes.

A YAML comment would be simpler, but [ITensorFormatter](https://github.com/ITensor/ITensorFormatter.jl) (`itpkgfmt`) strips comments when reformatting YAML — a consequence of writing through [YAML.jl](https://github.com/JuliaData/YAML.jl), whose writer does not preserve comments (tracked upstream at [YAML.jl#245](https://github.com/JuliaData/YAML.jl/issues/245)).

ITensorActions's README carries the full technical explanation; this README cross-references it and adds a short "do not remove this `env:` block" note.

Source is `examples/README.jl` (Literate.jl regenerates `README.md`). Bumps to v0.3.52.

## Test plan

- [x] No code changes; documentation only.
- [x] Pre-commit checks pass (yaml/toml/EOL/ITensor formatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)