### PR TITLE
template: fix "Github ursername" typo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.54"
+version = "0.3.55"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/README.md.template
+++ b/template/README.md.template
@@ -31,7 +31,7 @@ or:
 ```julia
 julia> Pkg.Registry.add(url = "git@github.com:ITensor/ITensorRegistry.git")
 ```
-if you want to use SSH credentials, which can make it so you don't have to enter your Github ursername and password when registering packages.
+if you want to use SSH credentials, which can make it so you don't have to enter your GitHub username and password when registering packages.
 
 Then, the package can be added as usual through the package manager:
 

--- a/template/examples/README.jl.template
+++ b/template/examples/README.jl.template
@@ -31,7 +31,7 @@ julia> Pkg.Registry.add(url = "https://github.com/ITensor/ITensorRegistry")
 julia> Pkg.Registry.add(url = "git@github.com:ITensor/ITensorRegistry.git")
 ```
 =#
-# if you want to use SSH credentials, which can make it so you don't have to enter your Github ursername and password when registering packages.
+# if you want to use SSH credentials, which can make it so you don't have to enter your GitHub username and password when registering packages.
 
 # Then, the package can be added as usual through the package manager:
 


### PR DESCRIPTION
## Summary

- Fix `Github ursername` → `GitHub username` in `template/README.md.template` and `template/examples/README.jl.template`.

Counterpart fix to #130, which fixed the same typo in the non-template `README.md` and `examples/README.jl` but did not propagate to the templates.