### PR TITLE
Drop redundant tag triggers from CI; restrict docs to v* tags

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
+    tags: ["v*"]
   pull_request: ~
   schedule:
     - cron: "1 4 * * 4"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
   pull_request_target:
     types:
       - "opened"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -5,7 +5,6 @@ on:
       - "master"
       - "main"
       - "release-"
-    tags: "*"
     paths-ignore:
       - "docs/**"
   pull_request:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.53"
+version = "0.3.54"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/Documentation.yml.template
+++ b/template/.github/workflows/Documentation.yml.template
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
+    tags: ["v*"]
   pull_request: ~
   schedule:
     - cron: "1 4 * * 4"

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
   pull_request_target:
     types:
       - "opened"

--- a/template/.github/workflows/Tests.yml.template
+++ b/template/.github/workflows/Tests.yml.template
@@ -5,7 +5,6 @@ on:
       - "master"
       - "main"
       - "release-"
-    tags: "*"
     paths-ignore:
       - "docs/**"
   pull_request:


### PR DESCRIPTION
## Summary

Test and integration-test workflows currently re-run on every tag push. The same commit was already tested on merge to `main`, and tags fire after registration — re-running adds no signal. Documentation keeps tag triggering for Documenter.jl's versioned-docs flow but restricts to `v*` so subdir-package tags (e.g. `NDTensors-v0.4.27`) don't pollute the docs build.

## Background

The original PkgTemplates.jl design ships a single combined CI workflow where `tags: '*'` was needed so Documenter.jl's versioned-docs deploy job would fire on tag pushes. Splitting tests and docs into separate workflow files in this skeleton inherited the trigger block on both sides, so the test workflows have been firing on every tag push as a side-effect rather than for any active reason.

A recent failure mode that surfaced this: TagBot retroactively created subdir-prefixed tags (`NDTensors-v0.4.x`) pointing at old historical commits. In repos with `tags: '*'` test triggers, those retroactive tags fire modern CI against ancient commits that fail noisily because dependencies and the test harness have moved on. The same wildcard would also let subdir-prefixed tags trigger the docs workflow, where they would either no-op (Documenter ignores non-`v*` tags by default) or pollute the versioned-docs tree.

## Changes

| File | Change |
|---|---|
| `Tests.yml`, `Tests.yml.template` | Drop `tags: "*"` |
| `IntegrationTest.yml`, `IntegrationTest.yml.template` | Drop `tags: "*"` |
| `Documentation.yml`, `Documentation.yml.template` | `tags: "*"` → `tags: ["v*"]` |
| `Project.toml` | Patch bump 0.3.53 → 0.3.54 |