### PR TITLE
Add explicit permissions blocks to caller workflow templates

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,6 +1,8 @@
 name: "Check Compat Bounds"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   check-compat-bounds:
     name: "Check Compat Bounds"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,6 +10,8 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}"
+permissions:
+  contents: "write"
 jobs:
   build-and-deploy-docs:
     name: "Documentation"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -6,6 +6,8 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+permissions:
+  contents: "read"
 jobs:
   format-check:
     name: "Format Check"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -5,12 +5,12 @@ on:
       - "Format Check"
     types:
       - "completed"
+permissions:
+  pull-requests: "write"
+  actions: "read"
 jobs:
   comment:
     name: "Format Check Comment"
     if: "github.event.workflow_run.event == 'pull_request'"
-    permissions:
-      pull-requests: "write"
-      actions: "read"
     uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
     secrets: "inherit"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,6 +11,9 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+permissions:
+  actions: "read"
+  contents: "read"
 jobs:
   integration-test:
     name: "IntegrationTest"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: ~
 env:
   REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
+permissions:
+  contents: "write"
+  issues: "read"
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,6 +19,8 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
+permissions:
+  contents: "read"
 jobs:
   tests:
     name: "Tests"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -1,6 +1,9 @@
 name: "Version Check"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
+  pull-requests: "read"
 jobs:
   version-check:
     name: "Version Check"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.57"
+version = "0.3.58"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/CheckCompatBounds.yml.template
+++ b/template/.github/workflows/CheckCompatBounds.yml.template
@@ -1,6 +1,8 @@
 name: "Check Compat Bounds"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   check-compat-bounds:
     name: "Check Compat Bounds"

--- a/template/.github/workflows/Documentation.yml.template
+++ b/template/.github/workflows/Documentation.yml.template
@@ -10,6 +10,8 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}"
+permissions:
+  contents: "write"
 jobs:
   build-and-deploy-docs:
     name: "Documentation"

--- a/template/.github/workflows/FormatCheck.yml.template
+++ b/template/.github/workflows/FormatCheck.yml.template
@@ -6,6 +6,8 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+permissions:
+  contents: "read"
 jobs:
   format-check:
     name: "Format Check"

--- a/template/.github/workflows/FormatCheckComment.yml.template
+++ b/template/.github/workflows/FormatCheckComment.yml.template
@@ -5,12 +5,12 @@ on:
       - "Format Check"
     types:
       - "completed"
+permissions:
+  pull-requests: "write"
+  actions: "read"
 jobs:
   comment:
     name: "Format Check Comment"
     if: "github.event.workflow_run.event == 'pull_request'"
-    permissions:
-      pull-requests: "write"
-      actions: "read"
     uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
     secrets: "inherit"

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -11,6 +11,9 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+permissions:
+  actions: "read"
+  contents: "read"
 jobs:
   integration-test:
     name: "IntegrationTest"

--- a/template/.github/workflows/TagBot.yml.template
+++ b/template/.github/workflows/TagBot.yml.template
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: ~
 env:
   REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
+permissions:
+  contents: "write"
+  issues: "read"
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"

--- a/template/.github/workflows/Tests.yml.template
+++ b/template/.github/workflows/Tests.yml.template
@@ -19,6 +19,8 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
+permissions:
+  contents: "read"
 jobs:
   tests:
     name: "Tests"

--- a/template/.github/workflows/VersionCheck.yml.template
+++ b/template/.github/workflows/VersionCheck.yml.template
@@ -1,6 +1,9 @@
 name: "Version Check"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
+  pull-requests: "read"
 jobs:
   version-check:
     name: "Version Check"


### PR DESCRIPTION
## Summary

Adds explicit `permissions:` blocks to each of the workflow templates that callers consume. Previously most templates declared no `permissions:` block at all, so the resulting per-repo workflow files inherited their `GITHUB_TOKEN` ceiling from whatever the consuming repo's Actions default happened to be (currently `default_workflow_permissions: write` org-wide).

After this change, every workflow declares its own minimum ceiling in the YAML. Any future change to the org or per-repo Actions default can only narrow (never widen) what these workflows can do — the security posture lives in code review (the YAML diff) rather than in admin clicks.

## Per-workflow permissions

The minimum each workflow actually needs:

- **Tests**, **FormatCheck**, **CheckCompatBounds**: `contents: read` (checkout-only).
- **VersionCheck**: `contents: read`, `pull-requests: read` (reads the PR's changed-file list to decide whether a version bump is required).
- **IntegrationTest**: `actions: read`, `contents: read` (the gate job inspects matrix-leg results via the Actions API).
- **Documentation**: `contents: write` (gh-pages deploy).
- **TagBot**: `contents: write`, `issues: read` (creates the release tag, reads PR/issue refs for release notes).

Already-permissioned templates (`CompatHelper`, `FormatPullRequest`, `IntegrationTestRequest`, `Registrator`) were left unchanged. `FormatCheckComment` was normalized from a job-level block to a workflow-level block so all caller files follow the same shape.

## How it was verified

End-to-end on `ITensor/SparseArraysBase.jl` (PR #176) with that repo's per-repo Actions setting temporarily flipped to `default_workflow_permissions: read` and `can_approve_pull_request_reviews: false` — the same end state planned for the org defaults later. Without these blocks, three workflows fail to start with errors like *"The nested job 'tests' is requesting 'contents: write', but is only allowed 'contents: read'"*. With the blocks in place, all workflows pass under the read-only ceiling.

## Impact for downstream consumers

No behavior change. Each workflow continues to do exactly what it did before. After this lands, packages that re-render their workflows from the templates pick up the new permissions blocks; `MassApplyPatch` will propagate the same shape across the rest of the ecosystem in a follow-up sweep.