### PR TITLE
Migrate workflows + templates to ITensorActions v2

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,11 +1,11 @@
-name: "Check Compat Bounds"
+name: "CheckCompatBounds"
 on:
   pull_request: ~
 permissions:
   contents: "read"
 jobs:
   check-compat-bounds:
-    name: "Check Compat Bounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
+    name: "CheckCompatBounds"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -7,9 +7,9 @@ permissions:
   contents: "write"
   pull-requests: "write"
 jobs:
-  compat-helper:
+  compathelper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,9 +13,9 @@ concurrency:
 permissions:
   contents: "write"
 jobs:
-  build-and-deploy-docs:
+  documentation:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,4 +1,4 @@
-name: "Format Check"
+name: "FormatCheck"
 on:
   pull_request:
     types:
@@ -10,5 +10,5 @@ permissions:
   contents: "read"
 jobs:
   format-check:
-    name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
+    name: "FormatCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v2"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,16 +1,16 @@
-name: "Format Check Comment"
+name: "FormatCheckComment"
 on:
   workflow_run:
     workflows:
-      - "Format Check"
+      - "FormatCheck"
     types:
       - "completed"
 permissions:
   pull-requests: "write"
   actions: "read"
 jobs:
-  comment:
-    name: "Format Check Comment"
+  format-check-comment:
+    name: "FormatCheckComment"
     if: "github.event.workflow_run.event == 'pull_request'"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -1,4 +1,4 @@
-name: "Format Pull Request"
+name: "FormatPullRequest"
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -11,6 +11,6 @@ permissions:
   pull-requests: "write"
 jobs:
   format-pull-request:
-    name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
+    name: "FormatPullRequest"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -1,4 +1,4 @@
-name: "Integration Test Request"
+name: "IntegrationTestRequest"
 on:
   issue_comment:
     types:
@@ -9,11 +9,12 @@ permissions:
   checks: "write"
   pull-requests: "write"
 jobs:
-  integrationrequest:
+  integration-test-request:
+    name: "IntegrationTestRequest"
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -1,4 +1,4 @@
-name: "Register Package"
+name: "Registrator"
 on:
   workflow_dispatch: ~
   push:
@@ -15,8 +15,9 @@ permissions:
   pull-requests: "write"
   issues: "write"
 jobs:
-  Register:
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v1"
+  registrator:
+    name: "Registrator"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v2"
     with:
       localregistry: "ITensor/ITensorRegistry"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -10,7 +10,8 @@ permissions:
   contents: "write"
   issues: "read"
 jobs:
-  TagBot:
+  tagbot:
+    name: "TagBot"
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -34,7 +34,7 @@ jobs:
           - "ubuntu-latest"
           - "macOS-latest"
           - "windows-latest"
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -1,4 +1,4 @@
-name: "Version Check"
+name: "VersionCheck"
 on:
   pull_request: ~
 permissions:
@@ -6,7 +6,7 @@ permissions:
   pull-requests: "read"
 jobs:
   version-check:
-    name: "Version Check"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
+    name: "VersionCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.58"
+version = "0.3.59"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/CheckCompatBounds.yml.template
+++ b/template/.github/workflows/CheckCompatBounds.yml.template
@@ -1,11 +1,11 @@
-name: "Check Compat Bounds"
+name: "CheckCompatBounds"
 on:
   pull_request: ~
 permissions:
   contents: "read"
 jobs:
   check-compat-bounds:
-    name: "Check Compat Bounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
+    name: "CheckCompatBounds"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/template/.github/workflows/CompatHelper.yml.template
+++ b/template/.github/workflows/CompatHelper.yml.template
@@ -7,9 +7,9 @@ permissions:
   contents: "write"
   pull-requests: "write"
 jobs:
-  compat-helper:
+  compathelper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: "inherit"

--- a/template/.github/workflows/Documentation.yml.template
+++ b/template/.github/workflows/Documentation.yml.template
@@ -13,9 +13,9 @@ concurrency:
 permissions:
   contents: "write"
 jobs:
-  build-and-deploy-docs:
+  documentation:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets:

--- a/template/.github/workflows/FormatCheck.yml.template
+++ b/template/.github/workflows/FormatCheck.yml.template
@@ -1,4 +1,4 @@
-name: "Format Check"
+name: "FormatCheck"
 on:
   pull_request:
     types:
@@ -10,5 +10,5 @@ permissions:
   contents: "read"
 jobs:
   format-check:
-    name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
+    name: "FormatCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v2"

--- a/template/.github/workflows/FormatCheckComment.yml.template
+++ b/template/.github/workflows/FormatCheckComment.yml.template
@@ -1,16 +1,16 @@
-name: "Format Check Comment"
+name: "FormatCheckComment"
 on:
   workflow_run:
     workflows:
-      - "Format Check"
+      - "FormatCheck"
     types:
       - "completed"
 permissions:
   pull-requests: "write"
   actions: "read"
 jobs:
-  comment:
-    name: "Format Check Comment"
+  format-check-comment:
+    name: "FormatCheckComment"
     if: "github.event.workflow_run.event == 'pull_request'"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v2"
     secrets: "inherit"

--- a/template/.github/workflows/FormatPullRequest.yml.template
+++ b/template/.github/workflows/FormatPullRequest.yml.template
@@ -1,4 +1,4 @@
-name: "Format Pull Request"
+name: "FormatPullRequest"
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -11,6 +11,6 @@ permissions:
   pull-requests: "write"
 jobs:
   format-pull-request:
-    name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
+    name: "FormatPullRequest"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v2"
     secrets: "inherit"

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -17,7 +17,7 @@ permissions:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/template/.github/workflows/IntegrationTestRequest.yml.template
+++ b/template/.github/workflows/IntegrationTestRequest.yml.template
@@ -1,4 +1,4 @@
-name: "Integration Test Request"
+name: "IntegrationTestRequest"
 on:
   issue_comment:
     types:
@@ -9,11 +9,12 @@ permissions:
   checks: "write"
   pull-requests: "write"
 jobs:
-  integrationrequest:
+  integration-test-request:
+    name: "IntegrationTestRequest"
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/template/.github/workflows/Registrator.yml.template
+++ b/template/.github/workflows/Registrator.yml.template
@@ -1,4 +1,4 @@
-name: "Register Package"
+name: "Registrator"
 on:
   workflow_dispatch: ~
   push:
@@ -15,8 +15,9 @@ permissions:
   pull-requests: "write"
   issues: "write"
 jobs:
-  Register:
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v1"
+  registrator:
+    name: "Registrator"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v2"
     with:
       localregistry: "ITensor/ITensorRegistry"
     secrets: "inherit"

--- a/template/.github/workflows/TagBot.yml.template
+++ b/template/.github/workflows/TagBot.yml.template
@@ -10,7 +10,8 @@ permissions:
   contents: "write"
   issues: "read"
 jobs:
-  TagBot:
+  tagbot:
+    name: "TagBot"
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v2"
     secrets: "inherit"

--- a/template/.github/workflows/Tests.yml.template
+++ b/template/.github/workflows/Tests.yml.template
@@ -34,7 +34,7 @@ jobs:
           - "ubuntu-latest"
           - "macOS-latest"
           - "windows-latest"
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"

--- a/template/.github/workflows/VersionCheck.yml.template
+++ b/template/.github/workflows/VersionCheck.yml.template
@@ -1,4 +1,4 @@
-name: "Version Check"
+name: "VersionCheck"
 on:
   pull_request: ~
 permissions:
@@ -6,7 +6,7 @@ permissions:
   pull-requests: "read"
 jobs:
   version-check:
-    name: "Version Check"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
+    name: "VersionCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"


### PR DESCRIPTION
## Summary

Migrates this repo's own workflow callers AND the workflow templates to the renamed shape from `ITensorActions v2.0.0`. Two parallel sets of changes (in `.github/workflows/` and `template/.github/workflows/`) kept in sync per CLAUDE.md convention.

## What changes

For each of the 12 standard workflow files (caller copy + template copy):

- Workflow `name:` matches the file's basename (e.g. `FormatCheck.yml` → `name: "FormatCheck"`). Drops cases like `"Format Check"`, `"Integration Test Request"`, `"Register Package"`.
- Job display `name:` also matches the filename for single-job workflows.
- Job key is kebab-case lowercase, with brand names like `tagbot`/`compathelper` treated as single words rather than split on internal capitals (`Register` → `registrator`, `compat-helper` → `compathelper`, etc.).
- `uses: ITensor/ITensorActions/.github/workflows/X.yml@v1` → `@v2`.
- `FormatCheckComment.yml` `workflow_run.workflows:` trigger updated from `["Format Check"]` to `["FormatCheck"]` to match the renamed parse-phase workflow.

The end-state of the templates matches what `SparseArraysBase.jl`'s `main` already carries (verified live in https://github.com/ITensor/SparseArraysBase.jl/pull/177 — every required-context check from the new v2 ruleset reported under its new name and SUCCESS).

Patch version bumped to `0.3.59`.

## Rollout follow-up

Once this lands, the next step is the `ITensorOrgPatches` sweep that copies these templates into the rest of the standard repo set, and the matching ruleset updates (replacing old context names with new ones in each repo's branch ruleset).