### PR TITLE
Add CodeQL.yml caller workflow + template

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -1,0 +1,13 @@
+name: "CodeQL"
+on:
+  pull_request:
+    branches:
+      - "main"
+permissions:
+  contents: "read"
+  security-events: "write"
+  actions: "read"
+jobs:
+  codeql:
+    name: "CodeQL"
+    uses: "ITensor/ITensorActions/.github/workflows/CodeQL.yml@v2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.59"
+version = "0.3.60"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/CodeQL.yml.template
+++ b/template/.github/workflows/CodeQL.yml.template
@@ -1,0 +1,13 @@
+name: "CodeQL"
+on:
+  pull_request:
+    branches:
+      - "main"
+permissions:
+  contents: "read"
+  security-events: "write"
+  actions: "read"
+jobs:
+  codeql:
+    name: "CodeQL"
+    uses: "ITensor/ITensorActions/.github/workflows/CodeQL.yml@v2"


### PR DESCRIPTION
## Summary

Add the `CodeQL.yml` caller workflow + matching template that targets the new path-aware CodeQL Actions analysis reusable in `ITensor/ITensorActions` (shipped in v2.1.0). Replaces consumer-side CodeQL default-setup, which doesn't fire on fork PRs from external contributors and leaves the required `Analyze (actions)` check unreachable on those PRs.

The new caller reports a status check named `CodeQL / Analyze (actions)`. The `analyze` job runs full CodeQL on PRs that touch `.github/workflows/**`, reports success-without-running on PRs that don't, and reports `skipped` on fork PRs that touch workflow files (so auto-merge can't fire and a maintainer must consciously intervene).

Both copies updated per ITensorPkgSkeleton convention: `.github/workflows/CodeQL.yml` is the actual workflow this skeleton repo uses, and `template/.github/workflows/CodeQL.yml.template` is what MassApplyPatch installs into consumer repos during sweeps.

Tracked in full at `Projects/Ecosystem/codeql_advanced_setup/` in ITensorDevelopmentPlans. Followup steps after this lands: ITensorOrgPatches sweep patch, ecosystem rollout (disabling default-setup CodeQL on each repo, installing the caller), and ruleset-context rename across all 38 repos.

