### PR TITLE
Add cancel-in-progress concurrency block to PR-triggered consumer workflows

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,6 +1,9 @@
 name: "CheckCompatBounds"
 on:
   pull_request: ~
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
 jobs:

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - "main"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
   security-events: "write"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -6,6 +6,9 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
 jobs:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,6 +11,9 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   actions: "read"
   contents: "read"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -1,6 +1,9 @@
 name: "VersionCheck"
 on:
   pull_request: ~
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
   pull-requests: "read"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.60"
+version = "0.3.61"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/CheckCompatBounds.yml.template
+++ b/template/.github/workflows/CheckCompatBounds.yml.template
@@ -1,6 +1,9 @@
 name: "CheckCompatBounds"
 on:
   pull_request: ~
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
 jobs:

--- a/template/.github/workflows/CodeQL.yml.template
+++ b/template/.github/workflows/CodeQL.yml.template
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - "main"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
   security-events: "write"

--- a/template/.github/workflows/FormatCheck.yml.template
+++ b/template/.github/workflows/FormatCheck.yml.template
@@ -6,6 +6,9 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
 jobs:

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -11,6 +11,9 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   actions: "read"
   contents: "read"

--- a/template/.github/workflows/VersionCheck.yml.template
+++ b/template/.github/workflows/VersionCheck.yml.template
@@ -1,6 +1,9 @@
 name: "VersionCheck"
 on:
   pull_request: ~
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
 permissions:
   contents: "read"
   pull-requests: "read"


### PR DESCRIPTION
## Summary

- Add a `concurrency:` block to the remaining PR-triggered consumer workflows so a new push to a PR cancels the prior in-flight run for that workflow, matching the behavior already in `Tests.yml` and `Documentation.yml`.
- Touches `CheckCompatBounds.yml`, `CodeQL.yml`, `FormatCheck.yml`, `IntegrationTest.yml`, and `VersionCheck.yml`, plus the matching `template/.github/workflows/*.yml.template` files used by `MassApplyPatch`.
- `cancel-in-progress` is gated on `refs/pull/`, so cancellation only fires on PR refs and never on `main`/tag pushes.
- Bumps `ITensorPkgSkeleton` to v0.3.61.