### PR TITLE
Fix IntegrationTest.yml template to emit valid multi-line YAML

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.61"
+version = "0.3.62"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/ITensorPkgSkeleton.jl
+++ b/src/ITensorPkgSkeleton.jl
@@ -99,9 +99,10 @@ function format_downstreampkgs(user_replacements)
     pkgs =
         haskey(user_replacements, :downstreampkgs) ? user_replacements.downstreampkgs : []
     if isempty(pkgs)
-        downstreampkgs = ""
+        downstreampkgs = "        []"
     else
-        downstreampkgs = join(["      \"$(pkg)\"" for pkg in pkgs], ",\n")
+        entries = join(["          \"$(pkg)\"" for pkg in pkgs], ",\n")
+        downstreampkgs = "        [\n$entries\n        ]"
     end
     return merge(user_replacements, (; downstreampkgs))
 end

--- a/template/.github/workflows/IntegrationTest.yml.template
+++ b/template/.github/workflows/IntegrationTest.yml.template
@@ -24,4 +24,5 @@ jobs:
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkgs: |{DOWNSTREAMPKGS}
+      pkgs: |
+{DOWNSTREAMPKGS}


### PR DESCRIPTION
## Summary

The previous `IntegrationTest.yml.template` placed `{DOWNSTREAMPKGS}` on the same line as the `pkgs: |` block-scalar marker, and `format_downstreampkgs` joined entries without a leading newline or array wrapper. With downstream packages this produced invalid YAML; with no downstreams it produced a confusing empty literal block.

This PR fixes both halves so generation emits the multi-line JSON-array form already used across ecosystem packages and consumed by `ITensorActions/.github/workflows/IntegrationTest.yml@v2` via `fromJSON(inputs.pkgs)`:

- Non-empty: `pkgs: |\n        [\n          "Foo",\n          "Bar"\n        ]`
- Empty: `pkgs: |\n        []`

Existing tests (which check for `pkgs: |` and the package name) continue to pass; verified the generated YAML in both cases against a clean process.