### PR TITLE
Auto-register from release branches via a release-* push trigger

### DIFF
--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "main"
+      - "release-*"
     paths:
       - "Project.toml"
   issue_comment:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorPkgSkeleton"
 uuid = "3d388ab1-018a-49f4-ae50-18094d5f71ea"
-version = "0.3.62"
+version = "0.3.63"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/template/.github/workflows/Registrator.yml.template
+++ b/template/.github/workflows/Registrator.yml.template
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "main"
+      - "release-*"
     paths:
       - "Project.toml"
   issue_comment:


### PR DESCRIPTION
## Summary

We keep older versions of a package alive on maintenance branches named `release-<version>` (for example `release-0.21` for the 0.21.x series), where we backport fixes after `main` has moved on. When a fix on one of those branches bumps the version, we want it to register a new patch release automatically, the same as a version bump on `main`.

Right now registration only triggers on pushes to `main`/`master`, so a release from a maintenance branch has to be registered by hand. This adds `release-*` to the `Registrator.yml` push trigger, in both the live workflow and the template, so those releases register on their own.

The registration workflow already works on any branch, so this is only a trigger change. It still runs only when a commit changes `Project.toml`, and putting the glob in the template means new maintenance branches are covered without editing each one.